### PR TITLE
Add R2000 and R2001 as CEL admission rules

### DIFF
--- a/pkg/rules/r2000-exec-to-pod/README.md
+++ b/pkg/rules/r2000-exec-to-pod/README.md
@@ -1,0 +1,38 @@
+# R2000 — Exec to pod
+
+Detects exec operations on pods via the Kubernetes admission webhook.
+
+## Trigger
+
+This rule is evaluated by the operator's admission controller (not the
+node-agent). It fires when the API server processes a `pods/exec` subresource
+CONNECT — typically triggered by `kubectl exec <pod>` or any client that
+opens an exec stream.
+
+## CEL expression
+
+```cel
+event.Kind == "PodExecOptions"
+```
+
+The expression deliberately keys on `event.Kind` rather than
+`event.Resource`/`event.Subresource` so the rule remains stable if the
+Kubernetes API evolves. The pre-filter in the operator uses this same
+constraint to skip CEL evaluation for unrelated admission events.
+
+## Alert content
+
+- **Message:** `Exec to pod: <name> in namespace <ns> by <username>`
+- **UniqueID:** `<namespace>/<name>` — suitable for downstream deduplication.
+
+## MITRE
+
+- Tactic: TA0002 (Execution)
+- Technique: T1609 (Container Administration Command)
+
+## Notes
+
+- Profile dependency is `NotRequired` (2): admission rules evaluate API
+  objects, not runtime behavior, and do not consult application profiles.
+- This rule replaces the operator's hardcoded `R2000 Exec to Pod` Go
+  implementation.

--- a/pkg/rules/r2000-exec-to-pod/exec-to-pod.yaml
+++ b/pkg/rules/r2000-exec-to-pod/exec-to-pod.yaml
@@ -1,0 +1,29 @@
+apiVersion: kubescape.io/v1
+kind: Rules
+metadata:
+  name: exec-to-pod-rule
+  namespace: kubescape
+  labels:
+    app: kubescape
+spec:
+  rules:
+    - name: "Exec to pod"
+      enabled: true
+      id: "R2000"
+      description: "Detects exec operations on pods via the Kubernetes admission webhook (PodExecOptions CONNECT)"
+      expressions:
+        message: "'Exec to pod: ' + event.Name + ' in namespace ' + event.Namespace + ' by ' + event.UserInfo.Username"
+        uniqueId: "event.Namespace + '/' + event.Name"
+        ruleExpression:
+          - eventType: "k8s-admission"
+            expression: 'event.Kind == "PodExecOptions"'
+      profileDependency: 2
+      severity: 8
+      supportPolicy: false
+      isTriggerAlert: true
+      mitreTactic: "TA0002"
+      mitreTechnique: "T1609"
+      tags:
+        - "context:kubernetes"
+        - "admission"
+        - "exec"

--- a/pkg/rules/r2001-port-forward/README.md
+++ b/pkg/rules/r2001-port-forward/README.md
@@ -1,0 +1,36 @@
+# R2001 — Port forward to pod
+
+Detects port-forward operations on pods via the Kubernetes admission webhook.
+
+## Trigger
+
+Evaluated by the operator's admission controller (not the node-agent). Fires
+when the API server processes a `pods/portforward` subresource CONNECT —
+typically triggered by `kubectl port-forward <pod>` or any client that opens
+a port-forward stream.
+
+## CEL expression
+
+```cel
+event.Kind == "PodPortForwardOptions"
+```
+
+The expression keys on `event.Kind` so the operator's Kind pre-filter can
+short-circuit unrelated admission events.
+
+## Alert content
+
+- **Message:** `Port forward to pod: <name> in namespace <ns> by <username>`
+- **UniqueID:** `<namespace>/<name>` — suitable for downstream deduplication.
+
+## MITRE
+
+- Tactic: TA0011 (Command and Control)
+- Technique: T1090 (Proxy)
+
+## Notes
+
+- Profile dependency is `NotRequired` (2): admission rules evaluate API
+  objects, not runtime behavior.
+- This rule replaces the operator's hardcoded `R2001 Port Forward` Go
+  implementation.

--- a/pkg/rules/r2001-port-forward/port-forward.yaml
+++ b/pkg/rules/r2001-port-forward/port-forward.yaml
@@ -1,0 +1,29 @@
+apiVersion: kubescape.io/v1
+kind: Rules
+metadata:
+  name: port-forward-rule
+  namespace: kubescape
+  labels:
+    app: kubescape
+spec:
+  rules:
+    - name: "Port forward to pod"
+      enabled: true
+      id: "R2001"
+      description: "Detects port-forward operations on pods via the Kubernetes admission webhook (PodPortForwardOptions CONNECT)"
+      expressions:
+        message: "'Port forward to pod: ' + event.Name + ' in namespace ' + event.Namespace + ' by ' + event.UserInfo.Username"
+        uniqueId: "event.Namespace + '/' + event.Name"
+        ruleExpression:
+          - eventType: "k8s-admission"
+            expression: 'event.Kind == "PodPortForwardOptions"'
+      profileDependency: 2
+      severity: 5
+      supportPolicy: false
+      isTriggerAlert: true
+      mitreTactic: "TA0011"
+      mitreTechnique: "T1090"
+      tags:
+        - "context:kubernetes"
+        - "admission"
+        - "network"

--- a/rules-crd.yaml
+++ b/rules-crd.yaml
@@ -18,7 +18,7 @@ spec:
           uniqueId: "event.comm + '_' + event.exepath"
           ruleExpression:
             - eventType: "exec"
-              expression: "!ap.was_executed(event.containerId, parse.get_exec_path(event.args, event.comm))"
+              expression: "!ap.was_executed(event.containerId, parse.get_exec_path(event.args, event.comm)) && (event.exepath == \"\" || !ap.was_executed(event.containerId, event.exepath))"
         profileDependency: 0
         profileDataRequired:
           execs: all
@@ -198,7 +198,7 @@ spec:
           uniqueId: "eventType == 'exec' ? 'exec_' + event.comm : 'network_' + event.dstAddr"
           ruleExpression:
             - eventType: "exec"
-              expression: "(event.comm == 'kubectl' || event.exepath.endsWith('/kubectl')) && !ap.was_executed(event.containerId, parse.get_exec_path(event.args, event.comm))"
+              expression: "(event.comm == 'kubectl' || event.exepath.endsWith('/kubectl')) && !ap.was_executed(event.containerId, parse.get_exec_path(event.args, event.comm)) && (event.exepath == \"\" || !ap.was_executed(event.containerId, event.exepath))"
             - eventType: "network"
               expression: "event.pktType == 'OUTGOING' && k8s.is_api_server_address(event.dstAddr) && !nn.was_address_in_egress(event.containerId, event.dstAddr)"
         profileDependency: 0
@@ -358,7 +358,8 @@ spec:
               expression: >
                 (event.upperlayer == true ||
                  event.pupperlayer == true) &&
-                !ap.was_executed(event.containerId, parse.get_exec_path(event.args, event.comm))
+                !ap.was_executed(event.containerId, parse.get_exec_path(event.args, event.comm)) &&
+                (event.exepath == "" || !ap.was_executed(event.containerId, event.exepath))
         profileDependency: 1
         profileDataRequired:
           execs: all
@@ -431,7 +432,7 @@ spec:
           uniqueId: "event.comm"
           ruleExpression:
             - eventType: "exec"
-              expression: "!ap.was_executed(event.containerId, parse.get_exec_path(event.args, event.comm)) && k8s.get_container_mount_paths(event.namespace, event.podName, event.containerName).exists(mount, event.exepath.startsWith(mount) || parse.get_exec_path(event.args, event.comm).startsWith(mount))"
+              expression: "!ap.was_executed(event.containerId, parse.get_exec_path(event.args, event.comm)) && (event.exepath == \"\" || !ap.was_executed(event.containerId, event.exepath)) && k8s.get_container_mount_paths(event.namespace, event.podName, event.containerName).exists(mount, event.exepath.startsWith(mount) || parse.get_exec_path(event.args, event.comm).startsWith(mount))"
         profileDependency: 1
         profileDataRequired:
           execs: all
@@ -689,3 +690,43 @@ spec:
           - "syscalls"
           - "io_uring"
           - "applicationprofile"
+      - name: "Exec to pod"
+        enabled: true
+        id: "R2000"
+        description: "Detects exec operations on pods via the Kubernetes admission webhook (PodExecOptions CONNECT)"
+        expressions:
+          message: "'Exec to pod: ' + event.Name + ' in namespace ' + event.Namespace + ' by ' + event.UserInfo.Username"
+          uniqueId: "event.Namespace + '/' + event.Name"
+          ruleExpression:
+            - eventType: "k8s-admission"
+              expression: 'event.Kind == "PodExecOptions"'
+        profileDependency: 2
+        severity: 8
+        supportPolicy: false
+        isTriggerAlert: true
+        mitreTactic: "TA0002"
+        mitreTechnique: "T1609"
+        tags:
+          - "context:kubernetes"
+          - "admission"
+          - "exec"
+      - name: "Port forward to pod"
+        enabled: true
+        id: "R2001"
+        description: "Detects port-forward operations on pods via the Kubernetes admission webhook (PodPortForwardOptions CONNECT)"
+        expressions:
+          message: "'Port forward to pod: ' + event.Name + ' in namespace ' + event.Namespace + ' by ' + event.UserInfo.Username"
+          uniqueId: "event.Namespace + '/' + event.Name"
+          ruleExpression:
+            - eventType: "k8s-admission"
+              expression: 'event.Kind == "PodPortForwardOptions"'
+        profileDependency: 2
+        severity: 5
+        supportPolicy: false
+        isTriggerAlert: true
+        mitreTactic: "TA0011"
+        mitreTechnique: "T1090"
+        tags:
+          - "context:kubernetes"
+          - "admission"
+          - "network"


### PR DESCRIPTION
Add R2000 (exec-to-pod) and R2001 (port-forward) as CRD-defined CEL rules under the new `k8s-admission` event type.

Implements: https://github.com/kubescape/designs-and-proposals/pull/3 (merged).
Companion: https://github.com/kubescape/operator/pull/374 (CRD-driven CEL admission rules in operator).

## What's added

- `pkg/rules/r2000-exec-to-pod/` — YAML + README
- `pkg/rules/r2001-port-forward/` — YAML + README

Both rules use:
- `eventType: k8s-admission` (only the operator's admission controller evaluates this type; the node-agent ignores it)
- `profileDependency: 2` (NotRequired) — admission events look at API objects, not runtime behavior
- Expressions key on `event.Kind` so the operator's static Kind pre-filter can short-circuit unrelated events

## Regeneration drift

`rules-crd.yaml` was regenerated via `make generate-rules-crd`. The regen picked up unrelated drift in R0001/R0007/R1001/R1004 between the per-rule source YAMLs and the consolidated CRD — those updates already landed in the per-rule YAMLs but the CRD wasn't regenerated.

## No tests

The existing rule tests use the node-agent's CEL engine (`github.com/kubescape/node-agent/pkg/rulemanager/cel`). The admission CEL engine lives in the operator and has integration tests there that exercise the same expressions end-to-end.

## Test plan

- [x] `make generate-rules-crd` succeeds
- [x] `make lint-projection` reports no findings
- [x] End-to-end verified on a kind cluster against the companion operator PR — `kubectl exec` fires R2000, `kubectl port-forward` fires R2001