### PR TITLE
feat: add context:container tag to container-level rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ spec:
 | `tags` | array | Array of tags for categorization | Yes |
 | `state` | object | Rule state | No |
 
+### Context Tags
+
+The `tags` list includes machine-readable `context:*` labels that help agents decide where a rule should run. Context tags are additive, not exclusive, so a single rule may carry more than one when the behavior is meaningful in multiple environments.
+
+| Context tag | Meaning |
+|-------------|---------|
+| `context:host` | The behavior is meaningful from the host's point of view, such as host processes or host-mounted resources. |
+| `context:container` | The behavior is meaningful at the container boundary regardless of orchestrator. Use this for rules that should run for Kubernetes, ECS, or standalone container agents. |
+| `context:kubernetes` | The rule is valid in Kubernetes deployments. Keep this tag on container rules for backward compatibility with older agents, and use it by itself for Kubernetes-specific signals such as `kubectl exec`, `port-forward`, or service-account behavior. |
+
+Examples:
+
+- R0010 carries `context:host` and `context:container` because `/etc/shadow` access can be meaningful from a host workload or from a container that can see that file.
+- R2000 and R2001 remain Kubernetes-only because they are driven by Kubernetes API activity, not generic container behavior.
+
+The `Platforms` row in each rule README is human-facing documentation. The `context:*` tags are routing metadata, so they often overlap but are not interchangeable.
+
 ### Supported Event Types
 
 - `exec` - Process execution events

--- a/pkg/rules/r0001-unexpected-process-launched/unexpected-process-launched.yaml
+++ b/pkg/rules/r0001-unexpected-process-launched/unexpected-process-launched.yaml
@@ -27,6 +27,7 @@ spec:
       mitreTechnique: "T1059"
       tags:
         - "context:kubernetes"
+        - "context:container"
         - "anomaly"
         - "process"
         - "exec"

--- a/pkg/rules/r0002-unexpected-file-access/unexpected-file-access.yaml
+++ b/pkg/rules/r0002-unexpected-file-access/unexpected-file-access.yaml
@@ -57,6 +57,7 @@ spec:
       mitreTechnique: "T1005"
       tags:
         - "context:kubernetes"
+        - "context:container"
         - "anomaly"
         - "file"
         - "open"

--- a/pkg/rules/r0003-unexpected-system-call/unexpected-system-call.yaml
+++ b/pkg/rules/r0003-unexpected-system-call/unexpected-system-call.yaml
@@ -27,6 +27,7 @@ spec:
       mitreTechnique: "T1059"
       tags:
         - "context:kubernetes"
+        - "context:container"
         - "anomaly"
         - "syscall"
         - "applicationprofile"

--- a/pkg/rules/r0004-unexpected-capability-used/unexpected-capability-used.yaml
+++ b/pkg/rules/r0004-unexpected-capability-used/unexpected-capability-used.yaml
@@ -27,6 +27,7 @@ spec:
       mitreTechnique: "T1059"
       tags:
         - "context:kubernetes"
+        - "context:container"
         - "anomaly"
         - "capabilities"
         - "applicationprofile"

--- a/pkg/rules/r0005-unexpected-domain-request/unexpected-domain-request.yaml
+++ b/pkg/rules/r0005-unexpected-domain-request/unexpected-domain-request.yaml
@@ -27,6 +27,7 @@ spec:
       mitreTechnique: "T1071.004"
       tags:
         - "context:kubernetes"
+        - "context:container"
         - "dns"
         - "anomaly"
         - "networkprofile"

--- a/pkg/rules/r0008-read-environment-variables-procfs/read-environment-variables-procfs.yaml
+++ b/pkg/rules/r0008-read-environment-variables-procfs/read-environment-variables-procfs.yaml
@@ -34,6 +34,7 @@ spec:
       mitreTechnique: "T1552.001"
       tags:
         - "context:kubernetes"
+        - "context:container"
         - "anomaly"
         - "procfs"
         - "environment"

--- a/pkg/rules/r0010-unexpected-sensitive-file-access/unexpected-sensitive-file-access.yaml
+++ b/pkg/rules/r0010-unexpected-sensitive-file-access/unexpected-sensitive-file-access.yaml
@@ -28,6 +28,7 @@ spec:
       mitreTechnique: "T1005"
       tags:
         - "context:kubernetes"
+        - "context:container"
         - "context:host"
         - "files"
         - "anomaly"

--- a/pkg/rules/r0011-unexpected-egress-network-traffic/unexpected-egress-network-traffic.yaml
+++ b/pkg/rules/r0011-unexpected-egress-network-traffic/unexpected-egress-network-traffic.yaml
@@ -27,6 +27,7 @@ spec:
       mitreTechnique: "T1041"
       tags:
         - "context:kubernetes"
+        - "context:container"
         - "whitelisted"
         - "network"
         - "anomaly"

--- a/pkg/rules/r1001-exec-binary-not-in-base-image/exec-binary-not-in-base-image.yaml
+++ b/pkg/rules/r1001-exec-binary-not-in-base-image/exec-binary-not-in-base-image.yaml
@@ -31,6 +31,7 @@ spec:
       mitreTechnique: "T1036"
       tags:
         - "context:kubernetes"
+        - "context:container"
         - "exec"
         - "malicious"
         - "binary"

--- a/pkg/rules/r1003-malicious-ssh-connection/malicious-ssh-connection.yaml
+++ b/pkg/rules/r1003-malicious-ssh-connection/malicious-ssh-connection.yaml
@@ -27,6 +27,7 @@ spec:
       mitreTechnique: "T1021.001"
       tags:
         - "context:kubernetes"
+        - "context:container"
         - "ssh"
         - "connection"
         - "port"

--- a/pkg/rules/r1004-exec-from-mount/exec-from-mount.yaml
+++ b/pkg/rules/r1004-exec-from-mount/exec-from-mount.yaml
@@ -27,6 +27,7 @@ spec:
       mitreTechnique: "T1059"
       tags:
         - "context:kubernetes"
+        - "context:container"
         - "exec"
         - "mount"
         - "applicationprofile"

--- a/pkg/rules/r1006-unshare-syscall/unshare-syscall.yaml
+++ b/pkg/rules/r1006-unshare-syscall/unshare-syscall.yaml
@@ -28,6 +28,7 @@ spec:
       mitreTechnique: "T1611"
       tags:
         - "context:kubernetes"
+        - "context:container"
         - "unshare"
         - "escape"
         - "unshare"

--- a/pkg/rules/r1007-xmr-crypto-mining/xmr-crypto-mining.yaml
+++ b/pkg/rules/r1007-xmr-crypto-mining/xmr-crypto-mining.yaml
@@ -25,6 +25,7 @@ spec:
       mitreTechnique: "T1496"
       tags:
         - "context:kubernetes"
+        - "context:container"
         - "crypto"
         - "miners"
         - "malicious"

--- a/pkg/rules/r1030-unexpected-io_uring-operation/unexpected-io_uring-operation.yaml
+++ b/pkg/rules/r1030-unexpected-io_uring-operation/unexpected-io_uring-operation.yaml
@@ -27,6 +27,7 @@ spec:
       mitreTechnique: "T1218"
       tags:
         - "context:kubernetes"
+        - "context:container"
         - "syscalls"
         - "io_uring"
         - "applicationprofile"

--- a/rules-crd.yaml
+++ b/rules-crd.yaml
@@ -29,6 +29,7 @@ spec:
         mitreTechnique: "T1059"
         tags:
           - "context:kubernetes"
+          - "context:container"
           - "anomaly"
           - "process"
           - "exec"
@@ -83,6 +84,7 @@ spec:
         mitreTechnique: "T1005"
         tags:
           - "context:kubernetes"
+          - "context:container"
           - "anomaly"
           - "file"
           - "open"
@@ -107,6 +109,7 @@ spec:
         mitreTechnique: "T1059"
         tags:
           - "context:kubernetes"
+          - "context:container"
           - "anomaly"
           - "syscall"
           - "applicationprofile"
@@ -130,6 +133,7 @@ spec:
         mitreTechnique: "T1059"
         tags:
           - "context:kubernetes"
+          - "context:container"
           - "anomaly"
           - "capabilities"
           - "applicationprofile"
@@ -153,6 +157,7 @@ spec:
         mitreTechnique: "T1071.004"
         tags:
           - "context:kubernetes"
+          - "context:container"
           - "dns"
           - "anomaly"
           - "networkprofile"
@@ -243,6 +248,7 @@ spec:
         mitreTechnique: "T1552.001"
         tags:
           - "context:kubernetes"
+          - "context:container"
           - "anomaly"
           - "procfs"
           - "environment"
@@ -317,6 +323,7 @@ spec:
         mitreTechnique: "T1041"
         tags:
           - "context:kubernetes"
+          - "context:container"
           - "whitelisted"
           - "network"
           - "anomaly"
@@ -370,6 +377,7 @@ spec:
         mitreTechnique: "T1036"
         tags:
           - "context:kubernetes"
+          - "context:container"
           - "exec"
           - "malicious"
           - "binary"
@@ -418,6 +426,7 @@ spec:
         mitreTechnique: "T1021.001"
         tags:
           - "context:kubernetes"
+          - "context:container"
           - "ssh"
           - "connection"
           - "port"
@@ -443,6 +452,7 @@ spec:
         mitreTechnique: "T1059"
         tags:
           - "context:kubernetes"
+          - "context:container"
           - "exec"
           - "mount"
           - "applicationprofile"
@@ -489,6 +499,7 @@ spec:
         mitreTechnique: "T1611"
         tags:
           - "context:kubernetes"
+          - "context:container"
           - "unshare"
           - "escape"
           - "unshare"
@@ -512,6 +523,7 @@ spec:
         mitreTechnique: "T1496"
         tags:
           - "context:kubernetes"
+          - "context:container"
           - "crypto"
           - "miners"
           - "malicious"
@@ -687,6 +699,7 @@ spec:
         mitreTechnique: "T1218"
         tags:
           - "context:kubernetes"
+          - "context:container"
           - "syscalls"
           - "io_uring"
           - "applicationprofile"

--- a/rules-crd.yaml
+++ b/rules-crd.yaml
@@ -299,6 +299,7 @@ spec:
         mitreTechnique: "T1005"
         tags:
           - "context:kubernetes"
+          - "context:container"
           - "context:host"
           - "files"
           - "anomaly"


### PR DESCRIPTION
## Summary

This PR introduces a `context:container` tag for rules that detect container-level security events (process execution, file access, syscalls, capabilities, network activity). Rules tagged `context:container` will fire on **any** container runtime — including both Kubernetes agents and ECS/standalone agents — rather than being restricted to Kubernetes-only deployments.

### What changed

- Added `- context:container` to the `tags` list of 13 rules that detect container-level behavior
- Added a README section documenting the difference between `context:host`, `context:container`, and `context:kubernetes`
- All existing `- context:kubernetes` tags are **kept unchanged** for backward compatibility with older agents that only understand the `kubernetes` context

### Why

We are introducing a `container` meta-context to allow ECS agents (and future standalone container agents) to consume the same rules that Kubernetes agents already use. Rules tagged `context:container` describe behaviors that are meaningful at the container boundary regardless of what orchestrator is managing that container.

Context tags are additive rather than exclusive, so a rule may carry more than one when the same behavior is meaningful in multiple environments. That is why **R0010** now carries `context:container` in addition to `context:host` and `context:kubernetes`.

### Rules updated

| Rule ID | Name | Why it's container-level |
|---------|------|--------------------------|
| R0001 | unexpected-process-launched | Process exec anomaly inside a container |
| R0002 | unexpected-file-access | File open anomaly inside a container |
| R0003 | unexpected-system-call | Syscall anomaly inside a container |
| R0004 | unexpected-capability-used | Linux capability anomaly inside a container |
| R0005 | unexpected-domain-request | DNS anomaly from a container |
| R0008 | read-environment-variables-procfs | procfs env-var read from a container process |
| R0010 | unexpected-sensitive-file-access | Sensitive file access from a container is still container-scoped even when the same rule also applies on hosts |
| R1001 | exec-binary-not-in-base-image | Binary drift detection (image layer check) |
| R1003 | malicious-ssh-connection | SSH connection anomaly from a container |
| R1004 | exec-from-mount | Execution from a mounted path in a container |
| R1006 | unshare-syscall | Container escape attempt via unshare |
| R1007 | xmr-crypto-mining | Crypto miner detection (randomx) in a container |
| R1030 | unexpected-io_uring-operation | io_uring anomaly inside a container |

### Rules intentionally skipped

Rules that are Kubernetes-API-specific were **not** tagged:
- **R2000** (exec-to-pod) — triggered by `kubectl exec`, a K8s API event
- **R2001** (port-forward) — triggered by `kubectl port-forward`, a K8s API event
- **R0006** (service-account-token) — Kubernetes service account token access
- **R0007** (kubernetes-client-executed) — K8s client binary execution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the context:container metadata tag across 14 security detection rules to improve categorization and container-specific routing.
* **Documentation**
  * Added a "Context Tags" section describing context:* tags, their meanings (host/container/kubernetes), and how they affect rule routing and platform indications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/rulelibrary/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->