### PR TITLE
refactor(rules): remove outcome-asserting bias from 5 rule names/descriptions/messages

### DIFF
--- a/pkg/rules/r1000-exec-from-malicious-source/exec-from-malicious-source.yaml
+++ b/pkg/rules/r1000-exec-from-malicious-source/exec-from-malicious-source.yaml
@@ -7,12 +7,12 @@ metadata:
     app: kubescape
 spec:
   rules:
-    - name: "Process executed from malicious source"
+    - name: "Process Executed from /dev/shm"
       enabled: true
       id: "R1000"
-      description: "Detecting exec calls that are from malicious source like: /dev/shm"
+      description: "Detecting exec calls whose executable path or working directory is under /dev/shm, a world-writable memory-backed (tmpfs) directory."
       expressions:
-        message: "'Execution from malicious source: ' + event.exepath + ' in directory ' + event.cwd"
+        message: "'Process executed from /dev/shm: ' + event.exepath + ' in directory ' + event.cwd"
         uniqueId: "event.comm + '_' + event.exepath + '_' + event.pcomm"
         ruleExpression:
           - eventType: "exec"

--- a/pkg/rules/r1000-exec-from-malicious-source/rule_test.go
+++ b/pkg/rules/r1000-exec-from-malicious-source/rule_test.go
@@ -159,7 +159,7 @@ func TestR1000ExecFromMaliciousSource(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Failed to evaluate message: %v", err)
 				}
-				expectedMessage := "Execution from malicious source: " + tt.event.ExePath + " in directory " + tt.event.Cwd
+				expectedMessage := "Process executed from /dev/shm: " + tt.event.ExePath + " in directory " + tt.event.Cwd
 				if message != expectedMessage {
 					t.Errorf("Message evaluation failed. Expected: %s, Got: %s", expectedMessage, message)
 				}

--- a/pkg/rules/r1003-malicious-ssh-connection/malicious-ssh-connection.yaml
+++ b/pkg/rules/r1003-malicious-ssh-connection/malicious-ssh-connection.yaml
@@ -7,12 +7,12 @@ metadata:
     app: kubescape
 spec:
   rules:
-    - name: "Disallowed ssh connection"
+    - name: "SSH Connection to Unexpected Destination on Non-Standard Port"
       enabled: false
       id: "R1003"
-      description: "Detecting ssh connection to disallowed port"
+      description: "Detecting an SSH connection to a non-standard port where the destination address is not in the container's learned egress baseline."
       expressions:
-        message: "'Malicious SSH connection attempt to ' + event.dstIp + ':' + string(dyn(event.dstPort))"
+        message: "'SSH connection to unexpected destination on non-standard port: ' + event.dstIp + ':' + string(dyn(event.dstPort))"
         uniqueId: "event.comm + '_' + event.dstIp + '_' + string(dyn(event.dstPort))"
         ruleExpression:
           - eventType: "ssh"

--- a/pkg/rules/r1003-malicious-ssh-connection/rule_test.go
+++ b/pkg/rules/r1003-malicious-ssh-connection/rule_test.go
@@ -84,7 +84,7 @@ func TestR1003MaliciousSSHConnection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to evaluate message: %v", err)
 	}
-	expectedMessage := "Malicious SSH connection attempt to 1.1.1.1:1234"
+	expectedMessage := "SSH connection to unexpected destination on non-standard port: 1.1.1.1:1234"
 	if message != expectedMessage {
 		t.Fatalf("Message evaluation failed, got: %s, expected: %s", message, expectedMessage)
 	}

--- a/pkg/rules/r1006-unshare-syscall/unshare-syscall.yaml
+++ b/pkg/rules/r1006-unshare-syscall/unshare-syscall.yaml
@@ -7,10 +7,10 @@ metadata:
     app: kubescape
 spec:
   rules:
-    - name: "Process tries to escape container"
+    - name: "Unexpected unshare Syscall in Container"
       enabled: true
       id: "R1006"
-      description: "Detecting Unshare System Call usage, which can be used to escape container."
+      description: "Detecting use of the unshare system call (a namespace-manipulation capability that can be used to escape a container) by a non-runc process, where it was not seen in the container's application-profile baseline."
       expressions:
         message: "'Unshare system call (unshare) was called by process (' + event.comm + ')'"
         uniqueId: "event.comm + '_' + 'unshare'"

--- a/pkg/rules/r1011-ld-preload-hook/ld-preload-hook.yaml
+++ b/pkg/rules/r1011-ld-preload-hook/ld-preload-hook.yaml
@@ -7,10 +7,10 @@ metadata:
     app: kubescape
 spec:
   rules:
-    - name: "ld_preload hooks technique detected"
+    - name: "ld_preload Mechanism Use or ld.so.preload Modification"
       enabled: false
       id: "R1011"
-      description: "Detecting ld_preload hook techniques."
+      description: "Detecting use of the LD_PRELOAD/LD_LIBRARY_PATH dynamic-linker hook mechanism, or an unexpected write to /etc/ld.so.preload relative to the container's application-profile baseline."
       expressions:
         message: "eventType == 'exec' ? 'Process (' + event.comm + ') is using a dynamic linker hook: ' + process.get_ld_hook_var(event.pid) : 'The dynamic linker configuration file (' + event.path + ') was modified by process (' + event.comm + ')'"
         uniqueId: "eventType == 'exec' ? 'exec_' + event.comm : 'open_' + event.path"

--- a/pkg/rules/r1015-malicious-ptrace-usage/malicious-ptrace-usage.yaml
+++ b/pkg/rules/r1015-malicious-ptrace-usage/malicious-ptrace-usage.yaml
@@ -7,12 +7,12 @@ metadata:
     app: kubescape
 spec:
   rules:
-    - name: "Malicious Ptrace Usage"
+    - name: "Unexpected Ptrace Syscall Usage"
       enabled: true
       id: "R1015"
-      description: "Detecting potentially malicious ptrace usage."
+      description: "Detecting use of the ptrace syscall that was not seen in the container's application-profile baseline."
       expressions:
-        message: "'Malicious ptrace usage detected from: ' + event.comm"
+        message: "'Unexpected ptrace syscall usage from: ' + event.comm"
         uniqueId: "event.exepath + '_' + event.comm"
         ruleExpression:
           - eventType: "ptrace"

--- a/pkg/rules/r1015-malicious-ptrace-usage/rule_test.go
+++ b/pkg/rules/r1015-malicious-ptrace-usage/rule_test.go
@@ -86,7 +86,7 @@ func TestR1015MaliciousPtraceUsage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to evaluate message: %v", err)
 	}
-	expectedMessage := "Malicious ptrace usage detected from: malicious_process"
+	expectedMessage := "Unexpected ptrace syscall usage from: malicious_process"
 	if message != expectedMessage {
 		t.Fatalf("Message evaluation failed. Expected: %s, Got: %s", expectedMessage, message)
 	}


### PR DESCRIPTION
## Summary

Five runtime rules are named/described in terms of a malicious **outcome** or **intent** that the underlying CEL does not actually prove — the CEL only proves an anomalous behavior or a path/syscall match. Downstream consumers that surface or reason over the rule name/description/message (UIs, alert text, AI severity classifiers) are anchored by the loaded wording and over-escalate. This aligns the five with the library's own existing **"Unexpected …"** convention used for profile-deviation detections.

Only `name` / `description` / `message` text literals change. `ruleExpression` CEL logic, rule IDs, `severity`, MITRE tactics/techniques, and `tags` are untouched. Tests updated to match; all pass.

## Changes

| ID | Before | After | Why |
|----|--------|-------|-----|
| R1000 | Process executed from **malicious source** | Process Executed from /dev/shm | CEL only matches exepath/cwd under `/dev/shm` (a writable tmpfs) — no malware signature or intent |
| R1015 | **Malicious** Ptrace Usage | Unexpected Ptrace Syscall Usage | Fires on any `ptrace` not in the application-profile baseline; debuggers/APM/runtimes use it legitimately |
| R1003 | Disallowed ssh connection (msg: "**Malicious** SSH connection attempt") | SSH Connection to Unexpected Destination on Non-Standard Port | Proves only an off-baseline SSH dest on a non-standard port |
| R1006 | Process tries to **escape container** | Unexpected unshare Syscall in Container | An `unshare` syscall is a namespace-manipulation *capability*, not a proven escape |
| R1011 | ld_preload **technique detected** | ld_preload Mechanism Use or ld.so.preload Modification | Proves the mechanism is in use / config modified — not that the library is malicious |

## Testing

`go test ./pkg/rules/{r1000,r1015,r1003,r1006,r1011}-...` — all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security rule alert messages for greater specificity and clarity.
  * Rule alerts now provide more precise descriptions of detected behaviors, including executable source locations, SSH connection destinations, container escape attempts, library preload hooks, and process tracing activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->