### PR TITLE
refactor(rules): neutralize overclaiming R1005 fileless-execution message

### DIFF
--- a/pkg/rules/r1005-fileless-execution/fileless-execution.yaml
+++ b/pkg/rules/r1005-fileless-execution/fileless-execution.yaml
@@ -12,7 +12,7 @@ spec:
       id: "R1005"
       description: "Detecting Fileless Execution"
       expressions:
-        message: '''Fileless execution detected: exec call "'' + event.comm + ''" is from a malicious source'''
+        message: '''Fileless execution detected: exec call "'' + event.comm + ''" runs from a memory-backed source (memfd / /proc/self/fd)'''
         uniqueId: "event.comm + '_' + event.exepath + '_' + event.pcomm"
         ruleExpression:
           - eventType: "exec"

--- a/pkg/rules/r1005-fileless-execution/rule_test.go
+++ b/pkg/rules/r1005-fileless-execution/rule_test.go
@@ -81,7 +81,7 @@ func TestR1005FilelessExecution(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to evaluate message: %v", err)
 	}
-	expectedMessage := "Fileless execution detected: exec call \"/memfd:test\" is from a malicious source"
+	expectedMessage := "Fileless execution detected: exec call \"/memfd:test\" runs from a memory-backed source (memfd / /proc/self/fd)"
 	if message != expectedMessage {
 		t.Fatalf("Message evaluation failed, got: %s, expected: %s", message, expectedMessage)
 	}


### PR DESCRIPTION
## Summary

Follow-up to #37. The **R1005** (fileless execution) alert message asserted the exec `"is from a malicious source"`, which the CEL does not prove.

**CEL proves:** exec where exepath is `memfd`, `/proc/self/fd/*`, or `/proc/<pid>/fd/*` — i.e. memory-backed ("fileless") execution. This is a strong malware TTP, but `memfd`/anonymous-fd exec is also used by legitimate loaders, packers, and some language runtimes. So the message over-asserts intent (consumers that surface or reason over the message — UIs, AI severity classifiers — get anchored upward).

**Change:** message only.

```
'… exec call "' + event.comm + '" is from a malicious source'
→
'… exec call "' + event.comm + '" runs from a memory-backed source (memfd / /proc/self/fd)'
```

Name (`Fileless execution detected`), description, `ruleExpression` CEL, severity, MITRE, and tags are unchanged. The name is accurate as-is ("fileless execution" is the recognized term). Test updated; passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated fileless execution detection alert messages to provide more specific details about memory-backed execution sources, making security findings more informative and precise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->