### PR TITLE
feat(R1016): add Signed Profile Tampered rule (metadata-only)

### DIFF
--- a/pkg/rules/r1016-signed-profile-tampered/README.md
+++ b/pkg/rules/r1016-signed-profile-tampered/README.md
@@ -1,0 +1,45 @@
+# R1016 — Signed Profile Tampered
+
+| Field | Value |
+|-------|-------|
+| Severity | Critical |
+| MITRE Tactic | Defense Evasion (TA0005) |
+| MITRE Technique | Impair Defenses (T1562) |
+| Platforms | Host, Kubernetes |
+| Requires Application Profile | No |
+| Trigger | Code-emitted (no eBPF event / CEL expression) |
+
+## Description
+
+Detects tampering with a cryptographically signed, user-managed profile —
+an `ApplicationProfile` or `NetworkNeighborhood` referenced by a pod via the
+`kubescape.io/user-defined-profile` label and signed under the
+`signature.kubescape.io/*` annotations.
+
+node-agent re-verifies the signature every time the profile is loaded into the
+`ContainerProfileCache`. When the signature annotation is **present but no
+longer valid** — i.e. the profile content was modified after it was signed —
+node-agent emits this alert. A missing/unsigned profile does not trigger it
+(signing is opt-in), and operational errors (e.g. malformed annotations) are
+explicitly excluded so they cannot raise a false R1016.
+
+Unlike the eBPF-driven rules in this library, R1016 has **no triggering event
+type and no CEL expression**: it is emitted directly from node-agent's tamper
+-detection code path. The entry here exists so the rule's metadata (name,
+severity, MITRE mapping, tags) lives in the single source of truth and flows
+into the bundled `default-rules.yaml` like every other rule.
+
+## Attack Technique
+
+An attacker who can edit a signed profile resource (for example via a
+compromised service account with write access to the CRD) could try to widen
+the allow-list — adding their own binary to the exec allow-list or their C2
+endpoint to the network allow-list — to evade the profile-based detections.
+Because the overlay is signed, any such edit invalidates the signature, and
+R1016 surfaces the tampering.
+
+## Remediation
+
+Investigate who modified the profile and when. Re-sign the profile after
+verifying its contents, and review RBAC so that only trusted principals can
+write user-managed `ApplicationProfile` / `NetworkNeighborhood` resources.

--- a/pkg/rules/r1016-signed-profile-tampered/signed-profile-tampered.yaml
+++ b/pkg/rules/r1016-signed-profile-tampered/signed-profile-tampered.yaml
@@ -1,0 +1,28 @@
+apiVersion: kubescape.io/v1
+kind: Rules
+metadata:
+  name: signed-profile-tampered-rule
+  namespace: kubescape
+  labels:
+    app: kubescape
+spec:
+  rules:
+    - name: "Signed profile tampered"
+      enabled: true
+      id: "R1016"
+      description: "Detecting tampering with a cryptographically signed user-managed profile (ApplicationProfile or NetworkNeighborhood): the signature annotation is present but no longer verifies. This alert is emitted by node-agent when it re-verifies a signed user overlay on profile-cache load, not in response to an eBPF event, so it carries no CEL ruleExpression."
+      expressions:
+        message: "'Signed profile tampered: signature present but no longer valid'"
+        uniqueId: "'R1016'"
+        ruleExpression: []
+      profileDependency: 2
+      severity: 10
+      supportPolicy: false
+      isTriggerAlert: true
+      mitreTactic: "TA0005"
+      mitreTechnique: "T1562"
+      tags:
+        - "context:kubernetes"
+        - "context:host"
+        - "signature"
+        - "malicious"

--- a/rules-crd.yaml
+++ b/rules-crd.yaml
@@ -704,6 +704,25 @@ spec:
           - "context:host"
           - "process"
           - "malicious"
+      - name: "Signed profile tampered"
+        enabled: true
+        id: "R1016"
+        description: "Detecting tampering with a cryptographically signed user-managed profile (ApplicationProfile or NetworkNeighborhood): the signature annotation is present but no longer verifies. This alert is emitted by node-agent when it re-verifies a signed user overlay on profile-cache load, not in response to an eBPF event, so it carries no CEL ruleExpression."
+        expressions:
+          message: "'Signed profile tampered: signature present but no longer valid'"
+          uniqueId: "'R1016'"
+          ruleExpression: []
+        profileDependency: 2
+        severity: 10
+        supportPolicy: false
+        isTriggerAlert: true
+        mitreTactic: "TA0005"
+        mitreTechnique: "T1562"
+        tags:
+          - "context:kubernetes"
+          - "context:host"
+          - "signature"
+          - "malicious"
       - name: "Unexpected io_uring Operation Detected"
         enabled: true
         id: "R1030"


### PR DESCRIPTION
Adds **R1016 "Signed profile tampered"** to the rule library as the single source of truth, so it flows into node-agent's bundled `default-rules.yaml` via the normal `rules-crd.yaml` sync.

## Why metadata-only
R1016 is **code-emitted** by node-agent's tamper-detection path (`pkg/objectcache/containerprofilecache/tamper_alert.go`) when a cryptographically signed user-managed `ApplicationProfile`/`NetworkNeighborhood` is loaded and its signature is present but no longer valid. It is **not** triggered by an eBPF event, so — unlike every other rule here — it carries no `eventType` and an empty `ruleExpression`. node-agent's engine (`rulecreator.CreateRulesByEventType`) iterates `ruleExpression[].eventType`, so an empty list means the rule's metadata is registered but it is never CEL-evaluated (no spurious firing).

## Contents
- `pkg/rules/r1016-signed-profile-tampered/signed-profile-tampered.yaml` — name, id, description, severity 10 (Critical), MITRE Defense Evasion / Impair Defenses (TA0005 / T1562), tags, `isTriggerAlert: true`, empty `ruleExpression`.
- `pkg/rules/r1016-signed-profile-tampered/README.md`
- Regenerated `rules-crd.yaml` (R1016 inserted between R1015 and R1030; 30 rules total).

Companion to node-agent #808 (signing & tamper detection); node-agent's `default-rules.yaml` will be synced from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)